### PR TITLE
Updates to support execution on air-gapped with GIT_URL=false and OCP PAO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM centos:8
 USER root
 COPY run.sh /root
+
+# Uncomment for GIT_URL="false" 
+RUN curl -OL https://github.com/redhat-nfvpe/container-perf-tools/archive/master.zip \
+&& unzip master.zip && rm -f master.zip \
+&& mv container-perf-tools-master /root/container-tools
+
 RUN yum -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/rt-tests-1.8-11.el8.x86_64.rpm \
     && yum -y --enablerepo=extras install epel-release git which pciutils wget tmux \
       diffutils python3 net-tools libtool automake gcc gcc-c++ cmake autoconf \

--- a/sample-yamls/pod_cyclictest.yaml
+++ b/sample-yamls/pod_cyclictest.yaml
@@ -2,13 +2,21 @@ apiVersion: v1
 kind: Pod 
 metadata:
   name: cyclictest 
+  # Disable CPU balance with CRIO (yes this is disabling it)
+  cpu-load-balancing.crio.io: "true"
 spec:
+  # Map to the correct performance class in the cluster (from PAO)
+  runtimeClassName: performance-custom-class
   restartPolicy: Never 
   containers:
   - name: container-perf-tools 
     image: quay.io/jianzzha/perf-tools
     imagePullPolicy: IfNotPresent
+    # Request and Limits must be identical for the Pod to be assigned to the QoS Guarantee
     resources:
+      requests:
+        memory: "200Mi"
+        cpu: "4"
       limits:
         memory: "200Mi"
         cpu: "4"
@@ -17,9 +25,10 @@ spec:
       value: "cyclictest"
     - name: DURATION
       value: "1h"
-    - name: DISABLE_CPU_BALANCE
-      value: "y"
-      # DISABLE_CPU_BALANCE requires privileged=true
+    # # Following setting not required in OCP4.6+
+    # - name: DISABLE_CPU_BALANCE
+    #   value: "y"
+    #   # DISABLE_CPU_BALANCE requires privileged=true
     securityContext:
       privileged: true
       #capabilities:
@@ -27,7 +36,6 @@ spec:
       #    - SYS_NICE
       #    - IPC_LOCK
       #    - SYS_RAWIO
-
     volumeMounts:
     - mountPath: /dev/cpu_dma_latency
       name: cstate

--- a/sample-yamls/pod_stress_cyclictest.yaml
+++ b/sample-yamls/pod_stress_cyclictest.yaml
@@ -2,7 +2,11 @@ apiVersion: v1
 kind: Pod 
 metadata:
   name: cyclictest 
+  # Disable CPU balance with CRIO (yes this is disabling it)
+  cpu-load-balancing.crio.io: "true"
 spec:
+  # Map to the correct performance class in the cluster (from PAO)
+  runtimeClassName: performance-custom-class
   restartPolicy: Never 
   containers:
   - name: cyclictest

--- a/sample-yamls/pod_sysjitter.yaml
+++ b/sample-yamls/pod_sysjitter.yaml
@@ -2,7 +2,11 @@ apiVersion: v1
 kind: Pod 
 metadata:
   name: sysjitter 
+  # Disable CPU balance with CRIO (yes this is disabling it)
+  cpu-load-balancing.crio.io: "true"
 spec:
+  # Map to the correct performance class in the cluster (from PAO)
+  runtimeClassName: performance-custom-class
   restartPolicy: Never 
   containers:
   - name: container-perf-tools 


### PR DESCRIPTION
Proposed updates for:
- support execution on air-gapped environments with `GIT_URL="false"`
- The definition and use of the OCP PAO annotations for `cyclictest` Pods
- Adding 10s pause before the execution of any test to allow CPUManager to reconcile the cgroups