### PR TITLE
Correcting pod examples to include annotation section

### DIFF
--- a/sample-yamls/pod_cyclictest.yaml
+++ b/sample-yamls/pod_cyclictest.yaml
@@ -2,10 +2,12 @@ apiVersion: v1
 kind: Pod 
 metadata:
   name: cyclictest 
-  # Disable CPU balance with CRIO (yes this is disabling it)
-  cpu-load-balancing.crio.io: "true"
+  annotations:
+    # Disable CPU balance with CRIO (yes this is disabling it)
+    cpu-load-balancing.crio.io: "true"
 spec:
   # Map to the correct performance class in the cluster (from PAO)
+  # Identify class names with "oc get runtimeclass"
   runtimeClassName: performance-custom-class
   restartPolicy: Never 
   containers:
@@ -25,6 +27,11 @@ spec:
       value: "cyclictest"
     - name: DURATION
       value: "1h"
+    # cyclictest should run with an RT Priority of 95 when testing for RAN DU
+    - name: rt_priority
+      value: "95"
+    - name: INTERVAL
+      value: "1000"
     # # Following setting not required in OCP4.6+
     # - name: DISABLE_CPU_BALANCE
     #   value: "y"

--- a/sample-yamls/pod_stress_cyclictest.yaml
+++ b/sample-yamls/pod_stress_cyclictest.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: Pod 
 metadata:
   name: cyclictest 
-  # Disable CPU balance with CRIO (yes this is disabling it)
-  cpu-load-balancing.crio.io: "true"
+  annotations:
+    # Disable CPU balance with CRIO (yes this is disabling it)
+    cpu-load-balancing.crio.io: "true"
 spec:
   # Map to the correct performance class in the cluster (from PAO)
   runtimeClassName: performance-custom-class

--- a/sample-yamls/pod_sysjitter.yaml
+++ b/sample-yamls/pod_sysjitter.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: Pod 
 metadata:
   name: sysjitter 
-  # Disable CPU balance with CRIO (yes this is disabling it)
-  cpu-load-balancing.crio.io: "true"
+  annotations:
+    # Disable CPU balance with CRIO (yes this is disabling it)
+    cpu-load-balancing.crio.io: "true"
 spec:
   # Map to the correct performance class in the cluster (from PAO)
   runtimeClassName: performance-custom-class


### PR DESCRIPTION
- Correcting pod examples to include annotation section when disabling CPU load balancing
- Adding default rt_priority (95) and INTERVAL for RAN DU testing

Annotations reference:
https://docs.openshift.com/container-platform/4.6/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#performance-addon-operator-disabling-cpu-load-balancing-for-dpdk_cnf-master