### PR TITLE
Allow extra_opt to be defined in the environment.

### DIFF
--- a/cyclictest/cmd.sh
+++ b/cyclictest/cmd.sh
@@ -86,7 +86,6 @@ while (( $cindex < ${#cpus[@]} )); do
         ccount=$(($ccount + 1))
 done
 
-extra_opt=""
 if [[ "$release" = "7" ]]; then
     extra_opt="${extra_opt} -n"
 fi


### PR DESCRIPTION
This will allow passing options to the cyclictest such as `--smi` from the environment to the container.
