### PR TITLE
Improvements to oslat pod

### DIFF
--- a/Dockerfile-oslat
+++ b/Dockerfile-oslat
@@ -2,7 +2,7 @@ FROM centos:8
 USER root
 COPY oslat/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests.*.rpm).*/\1/p') \
+RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests-2.*.rpm).*/\1/p') \
     && yum -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/${RT_TEST} \
     && yum -y install which numactl-libs \
     && yum clean all && rm -rf /var/cache/yum \

--- a/README.md
+++ b/README.md
@@ -144,12 +144,15 @@ Podman run example:
 Build the oslat container image:
 `podman build -t <your repo tag> -f Dockerfile-oslat .`
 
-A pre-build oslat container image is located at: quay.io/jianzzha/oslat
+A pre-built oslat container image is located at: quay.io/jianzzha/oslat
 
 oslat supports the following enviroment variables:
-+ RUNTIME_SECONDS: test duration in seconds
-+ PRIO: RT priority used for the test threads
++ RUNTIME_SECONDS: test duration in seconds; default 10
++ PRIO: RT priority used for the test threads; default 1
 + DISABLE_CPU_BALANCE: set to 'y' to disable cpu balancing; default to 'n'
++ manual: choice of y/n; if enabled, don't kick off oslat, this is for debug purpose
++ delay: specify how many second to delay before test start; default 0
++ TRACE_THRESHOLD: stop the oslat test when threshold triggered (in usec); no default
 
 A sample pod_oslat.yaml can be found under the sample-yamls directory.
 

--- a/oslat/cmd.sh
+++ b/oslat/cmd.sh
@@ -7,6 +7,7 @@
 #	run_hwlatdetect (default 'n', choice y/n)
 #       manual (default 'n', choice y/n)
 #       delay   (default 0, specify how many second to delay before test start)
+#       TRACE_THRESHOLD (no default, stop the oslat test when threshold triggered (in usec))
 
 source common-libs/functions.sh
 
@@ -76,8 +77,14 @@ if [[ "${sibling}" =~ ^[0-9]+$ ]]; then
 fi
 echo "new cpu list: ${cyccore}"
 
- 
-echo "cmd to run: oslat -D ${RUNTIME_SECONDS} --rtprio ${PRIO} --cpu-list ${cyccore} --cpu-main-thread ${cpus[0]}"
+extra_args=""
+if [ -n "$TRACE_THRESHOLD" ]; then
+        extra_args="--trace-threshold=$TRACE_THRESHOLD"
+fi
+
+command="oslat -D ${RUNTIME_SECONDS} --rtprio ${PRIO} --cpu-list ${cyccore} --cpu-main-thread ${cpus[0]} ${extra_args}"
+
+echo "cmd to run: ${command}"
 
 if [ "${manual:-n}" == "y" ]; then
 	sleep infinity
@@ -88,7 +95,7 @@ if [ "${delay:-0}" != "0" ]; then
 	sleep ${delay}
 fi
 
-oslat -D ${RUNTIME_SECONDS} --rtprio ${PRIO} --cpu-list ${cyccore} --cpu-main-thread ${cpus[0]}
+$command
 
 sleep infinity
 

--- a/sample-yamls/pod_oslat.yaml
+++ b/sample-yamls/pod_oslat.yaml
@@ -3,9 +3,9 @@ kind: Pod
 metadata:
   name: oslat
   annotations:
-    cpu-load-balancing.crio.io: "true"
-    irq-load-balancing.crio.io: "true"
-    cpu-quota.crio.io: "true"
+    cpu-load-balancing.crio.io: "disable"
+    irq-load-balancing.crio.io: "disable"
+    cpu-quota.crio.io: "disable"
 spec:
   runtimeClassName: performance-cnv-sriov-profile
   restartPolicy: Never
@@ -20,11 +20,16 @@ spec:
     env:
     - name: PRIO 
       value: "1"
+    - name: delay
+      value: "0"
     - name: RUNTIME_SECONDS 
       value: "30"
     - name: DISABLE_CPU_BALANCE
       value: "n"
       # DISABLE_CPU_BALANCE requires privileged=true
+    - name: TRACE_THRESHOLD
+      value: ""
+      # TRACE_THRESHOLD requires privileged=true and debug volume
     securityContext:
       #privileged: true
       capabilities:
@@ -37,10 +42,14 @@ spec:
     volumeMounts:
     - mountPath: /dev/cpu_dma_latency
       name: cstate
+    #- mountPath: /sys/kernel/debug
+    #  name: debug
   volumes:
   - name: cstate
     hostPath:
       path: /dev/cpu_dma_latency
+  #- name: debug
+  #  hostPath:
+  #    path: /sys/kernel/debug
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
-  


### PR DESCRIPTION
Updates to oslat pod:
- Update oslat dockerfile to use rt-tests version 2 (container build
  was broken when rt-tests version 2 was released).
- Add support to oslat pod for ftrace - new TRACE_THRESHOLD env
  variable can be set to cause oslat to stop ftrace when a
  latency threshold is reached.
- Update sample yaml for oslat pod to include all supported env
  variables.