### PR TITLE
Cyclictest pod enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y unzip && curl -OL https://github.com/redhat-nfvpe/container-p
 && unzip master.zip && rm -f master.zip \
 && mv container-perf-tools-master /root/container-tools
 
-RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests.*.rpm).*/\1/p') \
+RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests-2.1-2.*.rpm).*/\1/p') \
     && yum -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/${RT_TEST} \
     && yum -y --enablerepo=extras install epel-release git which pciutils wget tmux \
       diffutils python3 net-tools libtool automake gcc gcc-c++ cmake autoconf \

--- a/Dockerfile-cyclictest
+++ b/Dockerfile-cyclictest
@@ -2,7 +2,7 @@ FROM centos:8
 USER root
 COPY cyclictest/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests.*.rpm).*/\1/p') \
+RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests-2.1-2.*.rpm).*/\1/p') \
     && yum -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/${RT_TEST} \
     && yum -y --enablerepo=extras install epel-release which tmux \
       python3 numactl-devel kernel-devel kernel-tools numactl-libs \

--- a/Dockerfile-oslat
+++ b/Dockerfile-oslat
@@ -2,7 +2,7 @@ FROM centos:8
 USER root
 COPY oslat/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests-2.*.rpm).*/\1/p') \
+RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests-2.1-2.*.rpm).*/\1/p') \
     && yum -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/${RT_TEST} \
     && yum -y install which numactl-libs \
     && yum clean all && rm -rf /var/cache/yum \

--- a/sample-yamls/pod_cyclictest.yaml
+++ b/sample-yamls/pod_cyclictest.yaml
@@ -3,8 +3,9 @@ kind: Pod
 metadata:
   name: cyclictest 
   annotations:
-    # Disable CPU balance with CRIO (yes this is disabling it)
-    cpu-load-balancing.crio.io: "true"
+    cpu-load-balancing.crio.io: "disable"
+    irq-load-balancing.crio.io: "disable"
+    cpu-quota.crio.io: "disable"
 spec:
   # Map to the correct performance class in the cluster (from PAO)
   # Identify class names with "oc get runtimeclass"

--- a/sample-yamls/pod_stress_cyclictest.yaml
+++ b/sample-yamls/pod_stress_cyclictest.yaml
@@ -3,8 +3,9 @@ kind: Pod
 metadata:
   name: cyclictest 
   annotations:
-    # Disable CPU balance with CRIO (yes this is disabling it)
-    cpu-load-balancing.crio.io: "true"
+    cpu-load-balancing.crio.io: "disable"
+    irq-load-balancing.crio.io: "disable"
+    cpu-quota.crio.io: "disable"
 spec:
   # Map to the correct performance class in the cluster (from PAO)
   runtimeClassName: performance-custom-class
@@ -28,7 +29,7 @@ spec:
       value: "cyclictest"
     - name: trace
       value: "false"
-    - name: stress_tool
+    - name: stress
       value: "stress-ng"
     securityContext:
       privileged: true


### PR DESCRIPTION
Making several enhancements to cyclictest pod:
- Upversion rt-tests to version 2.1-2 (did this for all containers
  as the existing Dockerfiles would no longer build)
- Updated README to give correct build command for cyclictest
  container. Also corrected some typos in this file.
- Enhance cyclictest container to use the --mainaffinity parameter
  to place the main cyclictest thread on its own cpu to avoid
  affecting the measurement threads. Followed the same model
  used by the oslat container.
- Removed all tabs from the cyclictest cmd.sh file so it is
  formatted properly regardless of what editor you use.
- Updated annotations in sample cyclictest yaml files.

Signed-off-by: bartwensley <bwensley@redhat.com>