### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/standalone-trafficgen/Dockerfile
+++ b/standalone-trafficgen/Dockerfile
@@ -8,11 +8,11 @@ RUN yum -y --enablerepo=extras install epel-release dpdk dpdk-tools \
        		net-tools \
        		tmux gettext
 RUN yum install -y python-pip
-RUN pip install --upgrade "pip < 21.0" \
-       && pip install --upgrade setuptools wheel \
-       && pip install grpcio \
-       && pip install grpcio-tools \
-       && pip install psutil \
+RUN pip install --no-cache-dir --upgrade "pip < 21.0" \
+       && pip install --no-cache-dir --upgrade setuptools wheel \
+       && pip install --no-cache-dir grpcio \
+       && pip install --no-cache-dir grpcio-tools \
+       && pip install --no-cache-dir psutil \
        && mkdir -p /opt/trex \
        && mkdir -p /var/log/tgen \
        && mkdir -p /root/tgen \

--- a/standalone-trafficgen/Dockerfile-py3
+++ b/standalone-trafficgen/Dockerfile-py3
@@ -7,11 +7,11 @@ RUN yum -y --enablerepo=extras install epel-release dpdk dpdk-tools \
        		gcc python3 python3-devel \
        		net-tools \
        		tmux gettext
-RUN python3 -m pip install --upgrade pip \
-       && python3 -m pip install --upgrade setuptools wheel \
-       && python3 -m pip install grpcio \
-       && python3 -m pip install grpcio-tools \
-       && python3 -m pip install psutil \
+RUN python3 -m pip install --no-cache-dir --upgrade pip \
+       && python3 -m pip install --no-cache-dir --upgrade setuptools wheel \
+       && python3 -m pip install --no-cache-dir grpcio \
+       && python3 -m pip install --no-cache-dir grpcio-tools \
+       && python3 -m pip install --no-cache-dir psutil \
        && mkdir -p /opt/trex \
        && mkdir -p /var/log/tgen \
        && mkdir -p /root/tgen \


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>