### PR TITLE
Fix container build and add delay option to cyclictest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM ubi8
 USER root
 COPY run.sh /root
 
@@ -9,13 +9,15 @@ RUN yum install -y unzip && curl -OL https://github.com/redhat-nfvpe/container-p
 
 RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests-2.1-2.*.rpm).*/\1/p') \
     && yum -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/${RT_TEST} \
-    && yum -y --enablerepo=extras install epel-release git which pciutils wget tmux \
+    && yum -y install git which pciutils wget tmux xz \
       diffutils python3 net-tools libtool automake gcc gcc-c++ cmake autoconf \
       unzip python3-six numactl-devel make kernel-devel numactl-libs \
       libibverbs libibverbs-devel rdma-core-devel \
       libibverbs-utils mstflint gettext \
-    && yum install -y libaio-devel libattr-devel libbsd-devel libcap-devel libgcrypt-devel \
-    && yum -y --enablerepo=epel-testing install uperf  stress-ng \
+    && yum -y install https://rpmfind.net/linux/epel/8/Everything/x86_64/Packages/l/libbsd-0.9.1-4.el8.x86_64.rpm \
+    && yum -y install https://rpmfind.net/linux/epel/8/Everything/x86_64/Packages/s/stress-ng-0.12.04-1.el8.x86_64.rpm \
+    && yum -y install https://rpmfind.net/linux/epel/8/Everything/x86_64/Packages/u/uperf-1.0.7-1.el8.x86_64.rpm \
+    && yum install -y libaio-devel libattr-devel libcap-devel libgcrypt-devel \
     && curl -L -o dpdk.tar.xz https://fast.dpdk.org/rel/dpdk-20.08.tar.xz \
     && mkdir -p /opt/dpdk && tar -xf dpdk.tar.xz -C /opt/dpdk && rm -rf dpdk.tar.xz \
     && pushd /opt/dpdk/dpdk* && sed -i 's/\(CONFIG_RTE_LIBRTE_MLX5_PMD=\)n/\1y/g' config/common_base \

--- a/Dockerfile-cyclictest
+++ b/Dockerfile-cyclictest
@@ -1,10 +1,10 @@
-FROM centos:8
+FROM ubi8
 USER root
 COPY cyclictest/cmd.sh /root
 COPY common-libs /root/common-libs
 RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests-2.1-2.*.rpm).*/\1/p') \
     && yum -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/${RT_TEST} \
-    && yum -y --enablerepo=extras install epel-release which tmux \
+    && yum -y install which tmux \
       python3 numactl-devel kernel-devel kernel-tools numactl-libs \
     && ln -s $(which python3) /usr/local/bin/python \
     && yum clean all && rm -rf /var/cache/yum \

--- a/Dockerfile-oslat
+++ b/Dockerfile-oslat
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM ubi8
 USER root
 COPY oslat/cmd.sh /root
 COPY common-libs /root/common-libs

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ cyclictest supports the following environment variables:
 + INTERVAL: set cyclictest -i parameter, default 1000
 + stress: choice of false/stress-ng
 + rt_priority: which rt priority is used to run the cyclictest; default 1
++ delay: specify how many seconds to delay before test start; default 0
 
 
 ### sysjitter test

--- a/cyclictest/cmd.sh
+++ b/cyclictest/cmd.sh
@@ -6,6 +6,7 @@
 #   INTERVAL (default "1000")
 #   stress (default "false", choices false/true)
 #   rt_priority (default "1")
+#   delay (default 0, specify how many seconds to delay before test start)
 
 source common-libs/functions.sh
 
@@ -111,6 +112,10 @@ command="cyclictest -q -D ${DURATION} -p ${rt_priority} -t ${ccount} -a ${cyccor
 
 echo "running cmd: ${command}"
 if [ "${manual:-n}" == "n" ]; then
+    if [ "${delay:-0}" != "0" ]; then
+        echo "sleep ${delay} before test"
+        sleep ${delay}
+    fi
     $command
 else
     sleep infinity

--- a/sample-yamls/pod_cyclictest.yaml
+++ b/sample-yamls/pod_cyclictest.yaml
@@ -33,6 +33,8 @@ spec:
       value: "95"
     - name: INTERVAL
       value: "1000"
+    - name: delay
+      value: "0"
     # # Following setting not required in OCP4.6+
     # - name: DISABLE_CPU_BALANCE
     #   value: "y"


### PR DESCRIPTION
None of the container builds were working now that centos8 has reached
EOL. Switched to using ubi8 as the base image instead.

Updated the cyclictest pod/script to support a delay parameter to
wait a specified time between the creation of the pod and when
cyclictest is executed.

Signed-off-by: bartwensley <bwensley@redhat.com>