### PR TITLE
Add support for stress-ng tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 FROM ubi8
 USER root
 COPY run.sh /root
-
-# Uncomment for GIT_URL="false"
-RUN yum install -y unzip && curl -OL https://github.com/redhat-nfvpe/container-perf-tools/archive/master.zip \
-&& unzip master.zip && rm -f master.zip \
-&& mv container-perf-tools-master /root/container-tools
+COPY . /root/container-tools
 
 RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/ 2>/dev/null | sed -n -r 's/.*href=\"(rt-tests-2.1-2.*.rpm).*/\1/p') \
     && yum -y install https://www.rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/${RT_TEST} \
@@ -15,7 +11,7 @@ RUN RT_TEST=$(curl -L https://www.rpmfind.net/linux/centos/8-stream/AppStream/x8
       libibverbs libibverbs-devel rdma-core-devel \
       libibverbs-utils mstflint gettext intel-cmt-cat \
     && yum -y install https://rpmfind.net/linux/epel/8/Everything/x86_64/Packages/l/libbsd-0.9.1-4.el8.x86_64.rpm \
-    && yum -y install https://rpmfind.net/linux/epel/8/Everything/x86_64/Packages/s/stress-ng-0.12.04-1.el8.x86_64.rpm \
+    && yum -y install https://rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/stress-ng-0.14.00-1.el8.x86_64.rpm \
     && yum -y install https://rpmfind.net/linux/epel/8/Everything/x86_64/Packages/u/uperf-1.0.7-1.el8.x86_64.rpm \
     && yum install -y libaio-devel libattr-devel libcap-devel libgcrypt-devel \
     && curl -L -o dpdk.tar.xz https://fast.dpdk.org/rel/dpdk-20.08.tar.xz \

--- a/Dockerfile-stress-ng
+++ b/Dockerfile-stress-ng
@@ -1,0 +1,12 @@
+FROM ubi8
+USER root
+COPY stress-ng/cmd.sh /root
+COPY common-libs /root/common-libs
+RUN yum -y install https://rpmfind.net/linux/centos/8-stream/AppStream/x86_64/os/Packages/stress-ng-0.14.00-1.el8.x86_64.rpm \
+    && yum clean all && rm -rf /var/cache/yum \
+    && curl -L -o /root/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
+    && chmod 777 /root/dumb-init \
+    && chmod 777 /root/cmd.sh
+WORKDIR /root
+ENTRYPOINT ["/root/dumb-init", "--"]
+CMD ["/root/cmd.sh"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ This project contains a set of containerized performance test tools that can be 
 evaluate performance related to data plane, such as dpdk enabled network throughput, real time kernel latency, 
 etc.
 
-## Directory layout for all-in-one test container
+There are two ways to use these tools:
++ all-in-one test container - A single container that includes all test tools
++ standalone test containers - A separate container for each test tool
+
+## All-in-one test container
+
+### Directory layout
 
 The Dockerfile file under the root directory defines the all-in-one container.
 
@@ -20,14 +26,7 @@ The run.sh under the repo root diretory is the entrance for the container image.
 repo to get the latest tools. It then executes the specified tool based on the yaml specification, with the environment 
 variables in the yaml file. The yaml examples for k8s can be found under the sample-yamls/ directory
 
-## Standalone test tool containers
-
-Each test tool can also be built as a standalone test container (versus included in the all-in-one container). Some of the 
-dockerfiles can be found under the root directory, suck as Dockerfile-cyclictest and Dockerfile-oslat. Other standalone test 
-containers may have their dockerfiles located in the individual sub directories, such as the standalone-testpmd and 
-standalone-trafficgen containers. To build those containers one needs to go to the individual directory and run podman build.
-
-## How to run the all-in-one test container 
+### How to run the all-in-one test container 
 
 There are two types of container tool use cases. The first type is to run the performance tool as container 
 image in a Kubernetes cluster and the performance tool will collect and report performance metrics of the 
@@ -44,6 +43,9 @@ to all tools. The second type is tool specific. Both are defined as name/value p
 
 The common env variables include:
 + GIT_URL: this points to your github fork of this repository, or this repository if no fork
+  + if the GIT_URL is not set, this repository will be used
+  + if the GIT_URL is set to "false", the tools in the image will be used (air gapped mode)
+
 + tool: which performance test to run, essentially it is one of the tool directory names
 
 The tool specific variables will be mentioned under each tool section.
@@ -83,7 +85,6 @@ uperf supports the following environment variables:
 + size: the tcp write buffer size
 + threads: number of threads 
 
-
 ### cyclictest test
 
 cyclictest is used to evaluate the real time kernel scheduler latency. 
@@ -97,6 +98,16 @@ cyclictest supports the following environment variables:
 + rt_priority: which rt priority is used to run the cyclictest; default 1
 + delay: specify how many seconds to delay before test start; default 0
 
+### stress-ng test
+
+stress-ng is used to load and stress cpus
+
+stress-ng supports the following environment variables:
++ tool: stress-ng, run this stress-ng tool
++ DURATION: how long the stress-ng will be run, default: 24 hours
++ CPU_METHOD: specify a cpu stress method, default: matrixprod
++ CPU_LOAD: load each CPU with P percent loading, default: 100
++ EXTRA_ARGS: passed directly to stress-ng command
 
 ### sysjitter test
 
@@ -150,7 +161,14 @@ Prerequisites:
 Podman run example:
 `podman run -it --rm --privileged  -v /sys:/sys -v /dev:/dev -v /lib/modules:/lib/modules --cpuset-cpus 4-11 -e tool=trafficgen -e pci_list=0000:03:00.0,0000:03:00.1  -e validation_seconds=10 quay.io/jianzzha/perf-tools`
 
-## How to run the standalone oslat test
+## Standalone test tool containers
+
+Each test tool can also be built as a standalone test container (versus included in the all-in-one container). Some of the 
+dockerfiles can be found under the root directory, suck as Dockerfile-cyclictest and Dockerfile-oslat. Other standalone test 
+containers may have their dockerfiles located in the individual sub directories, such as the standalone-testpmd and 
+standalone-trafficgen containers. To build those containers one needs to go to the individual directory and run podman build.
+
+### How to run the standalone oslat test
 
 Build the oslat container image:
 `podman build -t <your repo tag> -f Dockerfile-oslat .`
@@ -246,7 +264,7 @@ Test completed.
 
 ```
 
-## How to run hwlatdetect using oslat image
+### How to run hwlatdetect using oslat image
 
 The hwlatdetect can be tested using the pre-build oslat image located at: quay.io/jianzzha/oslat
 
@@ -284,7 +302,7 @@ Samples recorded: 0
 Samples exceeding threshold: 0
 ```
 
-## How to run the standalone cyclictest
+### How to run the standalone cyclictest
 
 Build the cyclictest container image:
 `podman build -t <your repo tag> -f Dockerfile-cyclictest .`
@@ -298,10 +316,23 @@ cyclictest supports the following environment variables:
 
 A sample pod_cyclictest.yaml can be found under the sample-yamls directory.
 
-## How to run the standalone testpmd
+### How to run the standalone stress-ng
+
+Build the stress-ng container image:
+`podman build -t <your repo tag> -f Dockerfile-stress-ng .`
+
+stress-ng supports the following environment variables:
++ DURATION: how long the stress-ng will be run, default: 24 hours
++ CPU_METHOD: specify a cpu stress method, default: matrixprod
++ CPU_LOAD: load each CPU with P percent loading, default: 100
++ EXTRA_ARGS: passed directly to stress-ng command
+
+A sample pod_stress_ng.yaml can be found under the sample-yamls directory.
+
+### How to run the standalone testpmd
 
 Refer to the [standalone-testpmd directory](https://github.com/redhat-nfvpe/container-perf-tools/tree/master/standalone-testpmd)
 
-## How to run the standalone trafficgen
+### How to run the standalone trafficgen
 
 Refer to the [standalone-trafficgen directory](https://github.com/redhat-nfvpe/container-perf-tools/tree/master/standalone-trafficgen)

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# env vars: GIT_URL (default https://github.com/jianzzha/container-tools.git)
-#           tool (choices: sysjitter/testpmd/cyclictest)
+# env vars: GIT_URL (default https://github.com/redhat-nfvpe/container-perf-tools.git)
+#           tool (choices: sysjitter/testpmd/cyclictest/stress-ng)
 
 function sigfunc() {
 	exit 0
@@ -25,8 +25,8 @@ cd /root/container-tools
 if [ -d /root/container-tools/$tool ]; then
     echo "found tool directory $tool"
 else
-    echo "env 'tool' not specified or tool directory $tool not exists!"
-    echo "availble tool directory:"
+    echo "env 'tool' not specified or tool directory $tool does not exist!"
+    echo "available tool directories:"
     echo "$(ls /root/container-tools)"
     sleep infinity 
 fi
@@ -34,7 +34,7 @@ fi
 if [ -f /root/container-tools/$tool/cmd.sh ]; then
     echo "found $tool/cmd.sh, executing"
 else
-    echo "tool/cmd.sh not exists, can't continue"
+    echo "tool/cmd.sh does not exist, can't continue"
     sleep infinity
 fi
 

--- a/sample-yamls/pod_stress_ng.yaml
+++ b/sample-yamls/pod_stress_ng.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: stress-ng
+  annotations:
+    cpu-load-balancing.crio.io: "disable"
+    irq-load-balancing.crio.io: "disable"
+    cpu-quota.crio.io: "disable"
+spec:
+  # Map to the correct performance class in the cluster (from PAO)
+  # Identify class names with "oc get runtimeclass"
+  runtimeClassName: performance-custom-class
+  restartPolicy: Never
+  containers:
+  - name: container-perf-tools
+    image: quay.io/jianzzha/perf-tools
+    imagePullPolicy: IfNotPresent
+    # Request and Limits must be identical for the Pod to be assigned to the QoS Guarantee
+    resources:
+      requests:
+        memory: "200Mi"
+        cpu: "4"
+      limits:
+        memory: "200Mi"
+        cpu: "4"
+    env:
+    # Use this to run tool from inside all-in-one image
+    #- name: GIT_URL
+    #  value: "false"
+    - name: tool
+      value: "stress-ng"
+    - name: DURATION
+      value: "1h"
+    - name: CPU_METHOD
+      value: "matrixprod"
+    - name: CPU_LOAD
+      value: "100"
+    - name: EXTRA_ARGS
+      value: ""
+  nodeSelector:
+    node-role.kubernetes.io/worker-rt: ""

--- a/stress-ng/cmd.sh
+++ b/stress-ng/cmd.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# env vars:
+#   DURATION (default "24h")
+#   CPU_METHOD (default "matrixprod")
+#   CPU_LOAD (default "100")
+#   EXTRA_ARGS (will be passed directly to stress-ng command)
+
+source common-libs/functions.sh
+
+function sigfunc() {
+    exit 0
+}
+
+echo "############# dumping env ###########"
+env
+echo "#####################################"
+
+echo " "
+echo "########## container info ###########"
+echo "/proc/cmdline:"
+cat /proc/cmdline
+echo "#####################################"
+
+echo "**** uid: $UID ****"
+if [[ -z "${DURATION}" ]]; then
+    DURATION="24h"
+fi
+
+if [[ -z "${CPU_METHOD}" ]]; then
+    CPU_METHOD="matrixprod"
+fi
+
+if [[ -z "${CPU_LOAD}" ]]; then
+    CPU_LOAD="100"
+fi
+
+for cmd in stress-ng; do
+    command -v $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but not installed. Aborting"; exit 1; }
+done
+
+cpulist=`get_allowed_cpuset`
+echo "allowed cpu list: ${cpulist}"
+
+uname=`uname -nr`
+echo "$uname"
+
+cpulist=`convert_number_range ${cpulist} | tr , '\n' | sort -n | uniq`
+
+declare -a cpus
+cpus=(${cpulist})
+
+trap sigfunc TERM INT SIGUSR1
+
+newcpulist=${cpus[0]}
+cindex=1
+ccount=1
+while (( $cindex < ${#cpus[@]} )); do
+    newcpulist="${newcpulist},${cpus[$cindex]}"
+    cindex=$(($cindex + 1))
+    ccount=$(($ccount + 1))
+done
+
+echo "cpu list: ${newcpulist}"
+
+command="stress-ng -t ${DURATION} --cpu ${ccount} --taskset ${newcpulist} --cpu-method ${CPU_METHOD} --cpu-load ${CPU_LOAD} --metrics-brief ${EXTRA_ARGS}"
+
+echo "running cmd: ${command}"
+if [ "${manual:-n}" == "n" ]; then
+    $command
+else
+    sleep infinity
+fi
+
+sleep infinity


### PR DESCRIPTION
Added support for stress-ng to both the all-in-one container and as a
standalone container. Also made some improvements:
- Main Dockerfile changed to build the tools from the repo where the
  build is done instead of downloading from github.
- Updated README to be more clear about the all-in-one vs. the
  standalone container and how GIT_URL is used.

Signed-off-by: Bart Wensley <bwensley@redhat.com>