### PR TITLE
Remove repo download functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ to all tools when run from the all-in-one test container. The second type is too
 name/value pairs under the container env spec.
 
 The common env variables include:
-+ GIT_URL: this points to your github fork of this repository, or this repository if no fork
-  + if the GIT_URL is not set, this repository will be used
-  + if the GIT_URL is set to "false", the tools in the image will be used (air gapped mode)
-
 + tool: which performance test to run, essentially it is one of the tool directory names
 
 The tool specific variables will be mentioned under each tool section.

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# env vars: GIT_URL (default https://github.com/redhat-nfvpe/container-perf-tools.git)
-#           tool (choices: sysjitter/testpmd/cyclictest/stress-ng)
+# env vars: tool (choices: sysjitter/testpmd/cyclictest/stress-ng)
 
 function sigfunc() {
 	exit 0
@@ -11,14 +10,6 @@ trap sigfunc TERM INT SIGUSR1
 echo "######################################"
 env
 echo "######################################"
-
-[ -n "${GIT_URL}" ] || GIT_URL="https://github.com/redhat-nfvpe/container-perf-tools.git"
-
-# Support for air-gapped use with built-in container-tools
-if [[ ! "${GIT_URL}" == "false" ]]; then
-        echo "git clone ${GIT_URL}"
-        git clone ${GIT_URL} /root/container-tools
-fi
 
 cd /root/container-tools
 

--- a/sample-yamls/pod-uperf-master.yaml
+++ b/sample-yamls/pod-uperf-master.yaml
@@ -9,8 +9,6 @@ spec:
     image: quay.io/jianzzha/perf-tools 
     imagePullPolicy: IfNotPresent
     env:
-    - name: GIT_URL
-      value: https://github.com/jianzzha/container-tools.git
     - name: tool
       value: uperf
     - name: mode 

--- a/sample-yamls/pod-uperf-slave.yaml
+++ b/sample-yamls/pod-uperf-slave.yaml
@@ -11,8 +11,6 @@ spec:
     ports:
     - containerPort: 20000
     env:
-    - name: GIT_URL
-      value: https://github.com/jianzzha/container-tools.git
     - name: tool
       value: uperf
     - name: mode 

--- a/sample-yamls/pod_cyclictest.yaml
+++ b/sample-yamls/pod_cyclictest.yaml
@@ -24,8 +24,6 @@ spec:
         memory: "200Mi"
         cpu: "4"
     env:
-    - name: GIT_URL
-      value: "false"
     - name: tool
       value: "cyclictest"
     - name: DURATION

--- a/sample-yamls/pod_hwlatdetect.yaml
+++ b/sample-yamls/pod_hwlatdetect.yaml
@@ -10,8 +10,6 @@ spec:
     imagePullPolicy: Always 
     # Request and Limits are not required - hwlat detector is done in the kernel
     env:
-    - name: GIT_URL
-      value: "false"
     - name: tool
       value: "hwlatdetect"
     - name: RUNTIME_SECONDS 

--- a/sample-yamls/pod_hwnoise.yaml
+++ b/sample-yamls/pod_hwnoise.yaml
@@ -23,8 +23,6 @@ spec:
         memory: "200Mi"
         cpu: "16"
     env:
-    - name: GIT_URL
-      value: "false"
     - name: tool
       value: "rtla"
     - name: COMMAND

--- a/sample-yamls/pod_oslat.yaml
+++ b/sample-yamls/pod_oslat.yaml
@@ -24,8 +24,6 @@ spec:
         memory: "200Mi"
         cpu: "4"
     env:
-    - name: GIT_URL
-      value: "false"
     - name: tool
       value: "oslat"
     - name: PRIO 

--- a/sample-yamls/pod_osnoise.yaml
+++ b/sample-yamls/pod_osnoise.yaml
@@ -23,8 +23,6 @@ spec:
         memory: "200Mi"
         cpu: "16"
     env:
-    - name: GIT_URL
-      value: "false"
     - name: tool
       value: "rtla"
     - name: COMMAND

--- a/sample-yamls/pod_stress_ng.yaml
+++ b/sample-yamls/pod_stress_ng.yaml
@@ -24,8 +24,6 @@ spec:
         memory: "200Mi"
         cpu: "4"
     env:
-    - name: GIT_URL
-      value: "false"
     - name: tool
       value: "stress-ng"
     - name: DURATION

--- a/sample-yamls/pod_sysjitter.yaml
+++ b/sample-yamls/pod_sysjitter.yaml
@@ -14,8 +14,6 @@ spec:
     image: quay.io/jianzzha/perf-tools
     imagePullPolicy: IfNotPresent
     env:
-    - name: GIT_URL
-      value: https://github.com/jianzzha/container-tools.git
     - name: tool
       value: "sysjitter"
     - name: RUNTIME_SECONDS 

--- a/sample-yamls/pod_testpmd.yaml
+++ b/sample-yamls/pod_testpmd.yaml
@@ -11,8 +11,6 @@ spec:
     image: quay.io/jianzzha/perf-tools 
     imagePullPolicy: IfNotPresent
     env:
-    - name: GIT_URL
-      value: https://github.com/jianzzha/container-tools.git
     - name: tool
       value: testpmd
     - name: ring_size

--- a/sample-yamls/pod_timerlat.yaml
+++ b/sample-yamls/pod_timerlat.yaml
@@ -23,8 +23,6 @@ spec:
         memory: "200Mi"
         cpu: "16"
     env:
-    - name: GIT_URL
-      value: "false"
     - name: tool
       value: "rtla"
     - name: COMMAND


### PR DESCRIPTION
For historical reasons, the all-in-one container supported a GIT_URL environment variable which allowed code to be downloaded at runtime and executed in the pod. This functionality is no longer required and poses a potential security risk so it is being removed.