### PR TITLE
Switch to fedora base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-FROM ubi8
+FROM fedora:39
 USER root
 COPY run.sh /root
 COPY . /root/container-tools
 
-RUN yum -y install rt-tests stress-ng \
+RUN yum -y install realtime-tests stress-ng dumb-init \
       git which pciutils wget tmux xz \
       diffutils python3 net-tools libtool automake gcc gcc-c++ cmake autoconf \
       unzip python3-six numactl-devel make kernel-devel numactl-libs \
       libibverbs libibverbs-devel rdma-core-devel \
       libibverbs-utils mstflint gettext intel-cmt-cat \
-      https://rpmfind.net/linux/epel/8/Everything/x86_64/Packages/l/libmd-1.1.0-1.el8.x86_64.rpm \
-      https://rpmfind.net/linux/epel/8/Everything/x86_64/Packages/l/libbsd-0.11.7-2.el8.x86_64.rpm \
-      https://rpmfind.net/linux/epel/8/Everything/x86_64/Packages/u/uperf-1.0.7-1.el8.x86_64.rpm \
+      libmd libbsd uperf \
       libaio-devel libattr-devel libcap-devel libgcrypt-devel \
     && curl -L -o dpdk.tar.xz https://fast.dpdk.org/rel/dpdk-20.08.tar.xz \
     && mkdir -p /opt/dpdk && tar -xf dpdk.tar.xz -C /opt/dpdk && rm -rf dpdk.tar.xz \
@@ -22,9 +20,7 @@ RUN yum -y install rt-tests stress-ng \
     && popd && rm -rf /opt/dpdk \
     && ln -s $(which python3) /usr/local/bin/python \
     && yum clean all && rm -rf /var/cache/yum \
-    && wget -O /root/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
-    && chmod 777 /root/dumb-init \
     && chmod 777 /root/run.sh
 WORKDIR /root
-ENTRYPOINT ["/root/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/root/run.sh"]

--- a/Dockerfile-cyclictest
+++ b/Dockerfile-cyclictest
@@ -1,12 +1,10 @@
-FROM ubi8
+FROM fedora:39
 USER root
 COPY cyclictest/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install rt-tests tmux stress-ng kernel-tools \
+RUN yum -y install realtime-tests tmux stress-ng kernel-tools dumb-init \
     && yum clean all && rm -rf /var/cache/yum \
-    && curl -L -o /root/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
-    && chmod 777 /root/dumb-init \
     && chmod 777 /root/cmd.sh
 WORKDIR /root
-ENTRYPOINT ["/root/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/root/cmd.sh"]

--- a/Dockerfile-hwlatdetect
+++ b/Dockerfile-hwlatdetect
@@ -1,12 +1,10 @@
-FROM ubi8
+FROM fedora:39
 USER root
 COPY hwlatdetect/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install rt-tests kernel-tools \
+RUN yum -y install realtime-tests kernel-tools dumb-init \
     && yum clean all && rm -rf /var/cache/yum \
-    && curl -L -o /root/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
-    && chmod 777 /root/dumb-init \
     && chmod 777 /root/cmd.sh
 WORKDIR /root
-ENTRYPOINT ["/root/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/root/cmd.sh"]

--- a/Dockerfile-oslat
+++ b/Dockerfile-oslat
@@ -1,12 +1,10 @@
-FROM ubi8
+FROM fedora:39
 USER root
 COPY oslat/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install rt-tests kernel-tools \
+RUN yum -y install realtime-tests kernel-tools dumb-init \
     && yum clean all && rm -rf /var/cache/yum \
-    && curl -L -o /root/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
-    && chmod 777 /root/dumb-init \
     && chmod 777 /root/cmd.sh
 WORKDIR /root
-ENTRYPOINT ["/root/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/root/cmd.sh"]

--- a/Dockerfile-rtla
+++ b/Dockerfile-rtla
@@ -3,11 +3,9 @@ FROM fedora:39
 USER root
 COPY rtla/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install rtla \
+RUN yum -y install rtla dumb-init \
     && yum clean all && rm -rf /var/cache/yum \
-    && curl -L -o /root/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
-    && chmod 777 /root/dumb-init \
     && chmod 777 /root/cmd.sh
 WORKDIR /root
-ENTRYPOINT ["/root/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/root/cmd.sh"]

--- a/Dockerfile-stress-ng
+++ b/Dockerfile-stress-ng
@@ -1,12 +1,10 @@
-FROM ubi8
+FROM fedora:39
 USER root
 COPY stress-ng/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install stress-ng \
+RUN yum -y install stress-ng dumb-init \
     && yum clean all && rm -rf /var/cache/yum \
-    && curl -L -o /root/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
-    && chmod 777 /root/dumb-init \
     && chmod 777 /root/cmd.sh
 WORKDIR /root
-ENTRYPOINT ["/root/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/root/cmd.sh"]

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ specified tool based on the yaml specification, with the environment variables i
 
 ### Building the container
 
-**Prerequisite:** A valid subscription manager registration is required to resolve some of the packages used by the containers.
-The yum process running inside the container will run using container mode and pass through the host's registration to allow
-resolving all the packages. If you attempt to build on a host without a valid subscription then some packages will not be able to install and the container build will fail.
-
 Build the all-in-one container image:
 `podman build -t <your repo tag> -f Dockerfile .`
 
@@ -56,10 +52,6 @@ containers may have their dockerfiles located in the individual sub directories,
 standalone-trafficgen containers. To build those containers one needs to go to the individual directory and run podman build.
 
 ### Building the container
-
-**Prerequisite:** A valid subscription manager registration is required to resolve some of the packages used by the containers.
-The yum process running inside the container will run using container mode and pass through the host's registration to allow
-resolving all the packages. If you attempt to build on a host without a valid subscription then some packages will not be able to install and the container build will fail.
 
 For example, to build the oslat container image:
 `podman build -t <your repo tag> -f Dockerfile-oslat .`

--- a/cyclictest/cmd.sh
+++ b/cyclictest/cmd.sh
@@ -60,7 +60,7 @@ done
 
 uname=`uname -nr`
 echo "$uname"
-rpm -q rt-tests
+rpm -q realtime-tests
 
 cpulist=`get_allowed_cpuset`
 echo "allowed cpu list: ${cpulist}"

--- a/hwlatdetect/cmd.sh
+++ b/hwlatdetect/cmd.sh
@@ -23,7 +23,7 @@ echo "#####################################"
 
 uname=`uname -nr`
 echo "$uname"
-rpm -q rt-tests
+rpm -q realtime-tests
 
 for cmd in hwlatdetect; do
     command -v $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but not installed.  Aborting"; exit 1; }

--- a/oslat/cmd.sh
+++ b/oslat/cmd.sh
@@ -27,7 +27,7 @@ PRIO=${PRIO:-1}
 
 uname=`uname -nr`
 echo "$uname"
-rpm -q rt-tests
+rpm -q realtime-tests
 
 cpulist=`get_allowed_cpuset`
 echo "allowed cpu list: ${cpulist}"

--- a/run.sh
+++ b/run.sh
@@ -37,4 +37,4 @@ fi
 echo "Pausing for 10s before executing $tool to allow CPU Manager to reconcile cgroups"
 sleep 10
 
-exec /root/dumb-init -- /root/container-tools/$tool/cmd.sh
+exec /usr/bin/dumb-init -- /root/container-tools/$tool/cmd.sh


### PR DESCRIPTION
Switching from ubi8 to fedora:39 as the base image for the containers. This has the following benefits:
- Registration with subscription manager is no longer required to build the images.
- Fedora has all the required packages available, so no longer need to download some RPMs manually. This makes the Dockerfile portable between architectures so it is possible to build aarch64 images as well.