### PR TITLE
Add compatibility for internal QE test automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ stress-ng supports the following environment variables:
 + CPU_METHOD: specify a cpu stress method, default: matrixprod
 + CPU_LOAD: load each CPU with P percent loading, default: 100
 + EXTRA_ARGS (default "", will be passed directly to stress-ng command)
++ CMDLINE (default "", the full set of options passed to stress-ng command, overrides all other options)
+
 
 ### sysjitter test
 

--- a/stress-ng/cmd.sh
+++ b/stress-ng/cmd.sh
@@ -5,6 +5,7 @@
 #   CPU_METHOD (default "matrixprod")
 #   CPU_LOAD (default "100")
 #   EXTRA_ARGS (default "", will be passed directly to stress-ng command)
+#   CMDLINE (default "", the full set of options passed to stress-ng command, overrides all other options)
 
 source common-libs/functions.sh
 
@@ -45,28 +46,34 @@ echo "allowed cpu list: ${cpulist}"
 uname=`uname -nr`
 echo "$uname"
 
-cpulist=`convert_number_range ${cpulist} | tr , '\n' | sort -n | uniq`
+if [ "${CMDLINE}" == "" ]; then
 
-declare -a cpus
-cpus=(${cpulist})
+    cpulist=`convert_number_range ${cpulist} | tr , '\n' | sort -n | uniq`
 
-trap sigfunc TERM INT SIGUSR1
+    declare -a cpus
+    cpus=(${cpulist})
 
-newcpulist=${cpus[0]}
-cindex=1
-ccount=1
-while (( $cindex < ${#cpus[@]} )); do
-    newcpulist="${newcpulist},${cpus[$cindex]}"
-    cindex=$(($cindex + 1))
-    ccount=$(($ccount + 1))
-done
+    trap sigfunc TERM INT SIGUSR1
 
-echo "cpu list: ${newcpulist}"
+    newcpulist=${cpus[0]}
+    cindex=1
+    ccount=1
+    while (( $cindex < ${#cpus[@]} )); do
+        newcpulist="${newcpulist},${cpus[$cindex]}"
+        cindex=$(($cindex + 1))
+        ccount=$(($ccount + 1))
+    done
 
-command="stress-ng -t ${DURATION} --cpu ${ccount} --taskset ${newcpulist} --cpu-method ${CPU_METHOD} --cpu-load ${CPU_LOAD} --metrics-brief ${EXTRA_ARGS}"
+    echo "cpu list: ${newcpulist}"
+
+    command="stress-ng -t ${DURATION} --cpu ${ccount} --taskset ${newcpulist} --cpu-method ${CPU_METHOD} --cpu-load ${CPU_LOAD} --metrics-brief ${EXTRA_ARGS}"
+else
+    command="stress-ng ${CMDLINE}"
+fi
 
 echo "running cmd: ${command}"
 if [ "${manual:-n}" == "n" ]; then
+    trap sigfunc TERM INT SIGUSR1
     $command
 else
     sleep infinity

--- a/stress-ng/cmd.sh
+++ b/stress-ng/cmd.sh
@@ -46,14 +46,12 @@ echo "allowed cpu list: ${cpulist}"
 uname=`uname -nr`
 echo "$uname"
 
-if [ "${CMDLINE}" == "" ]; then
+if [[ -z "${CMDLINE}" ]]; then
 
     cpulist=`convert_number_range ${cpulist} | tr , '\n' | sort -n | uniq`
 
     declare -a cpus
     cpus=(${cpulist})
-
-    trap sigfunc TERM INT SIGUSR1
 
     newcpulist=${cpus[0]}
     cindex=1
@@ -71,9 +69,11 @@ else
     command="stress-ng ${CMDLINE}"
 fi
 
+trap sigfunc TERM INT SIGUSR1
+
 echo "running cmd: ${command}"
+
 if [ "${manual:-n}" == "n" ]; then
-    trap sigfunc TERM INT SIGUSR1
     $command
 else
     sleep infinity


### PR DESCRIPTION
Required to preserve backwards compatibility with internal automation that utilizes stress-ng pods while preserving functionality of the other environment variable managed settings.