### PR TITLE
Remove crio annotations from sample stress-ng pod yaml

### DIFF
--- a/sample-yamls/pod_stress_ng.yaml
+++ b/sample-yamls/pod_stress_ng.yaml
@@ -2,14 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: stress-ng
-  annotations:
-    cpu-load-balancing.crio.io: "disable"
-    irq-load-balancing.crio.io: "disable"
-    cpu-quota.crio.io: "disable"
+  # Note: crio annotations are not required since this is not a low latency pod, and
+  # on some kernels, the cpu-load-balancing.crio.io annotation will interfere with
+  # stress-ng's ability to distribute threads to different CPUs.
 spec:
-  # Map to the correct performance class in the cluster (from PAO)
-  # Identify class names with "oc get runtimeclass"
-  runtimeClassName: performance-openshift-node-performance-profile
   restartPolicy: Never
   containers:
   - name: stress-ng


### PR DESCRIPTION
The crio annotation are not required for the stress-ng pod and in some cases can interfere with the ability of stress-ng to distribute threads to different CPUs.