### PR TITLE
Add build system for stand-alone test images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ bin/
 #relative/path/to/dir/anotherfile
 */__pycache__/
 
+# VS Code files and directories
+.vscode/

--- a/Dockerfile-cyclictest
+++ b/Dockerfile-cyclictest
@@ -1,10 +1,43 @@
-FROM fedora:39
+FROM fedora:42
+
+# Build arguments
+ARG COMMIT_SHA=unknown
+ARG BUILD_DATE
+ARG VERSION
+
+# Metadata labels following OCI image specification
+LABEL org.opencontainers.image.title="cyclictest performance testing container"
+LABEL org.opencontainers.image.description="Container for running cyclictest latency testing"
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.authors="Container Performance Tools Team"
+LABEL org.opencontainers.image.url="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.documentation="https://github.com/redhat-nfvpe/container-perf-tools/blob/main/README.md"
+LABEL org.opencontainers.image.source="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.licenses="GPL-2.0"
+LABEL org.opencontainers.image.vendor="Container Performance Tools Team"
+
+# Install packages and clean up in single layer for smaller image size
 USER root
 COPY cyclictest/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install realtime-tests tmux stress-ng kernel-tools dumb-init \
-    && yum clean all && rm -rf /var/cache/yum \
-    && chmod 777 /root/cmd.sh
+RUN yum -y update \
+    && yum -y install \
+        realtime-tests \
+        tmux \
+        stress-ng \
+        kernel-tools \
+        dumb-init \
+    && yum clean all \
+    && rm -rf /var/cache/yum \
+    && chmod +x /root/cmd.sh
+
+# Set working directory
 WORKDIR /root
+
+# Use dumb-init to handle signals properly
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Default command
 CMD ["/root/cmd.sh"]

--- a/Dockerfile-hwlatdetect
+++ b/Dockerfile-hwlatdetect
@@ -1,10 +1,41 @@
-FROM fedora:39
+FROM fedora:42
+
+# Build arguments
+ARG COMMIT_SHA=unknown
+ARG BUILD_DATE
+ARG VERSION
+
+# Metadata labels following OCI image specification
+LABEL org.opencontainers.image.title="hwlatdetect performance testing container"
+LABEL org.opencontainers.image.description="Container for running hwlatdetect hardware latency testing"
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.authors="Container Performance Tools Team"
+LABEL org.opencontainers.image.url="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.documentation="https://github.com/redhat-nfvpe/container-perf-tools/blob/main/README.md"
+LABEL org.opencontainers.image.source="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.licenses="GPL-2.0"
+LABEL org.opencontainers.image.vendor="Container Performance Tools Team"
+
+# Install packages and clean up in single layer for smaller image size
 USER root
 COPY hwlatdetect/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install realtime-tests kernel-tools dumb-init \
-    && yum clean all && rm -rf /var/cache/yum \
-    && chmod 777 /root/cmd.sh
+RUN yum -y update \
+    && yum -y install \
+        realtime-tests \
+        kernel-tools \
+        dumb-init \
+    && yum clean all \
+    && rm -rf /var/cache/yum \
+    && chmod +x /root/cmd.sh
+
+# Set working directory
 WORKDIR /root
+
+# Use dumb-init to handle signals properly
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Default command
 CMD ["/root/cmd.sh"]

--- a/Dockerfile-oslat
+++ b/Dockerfile-oslat
@@ -1,10 +1,41 @@
-FROM fedora:39
+FROM fedora:42
+
+# Build arguments
+ARG COMMIT_SHA=unknown
+ARG BUILD_DATE
+ARG VERSION
+
+# Metadata labels following OCI image specification
+LABEL org.opencontainers.image.title="oslat performance testing container"
+LABEL org.opencontainers.image.description="Container for running oslat OS latency testing"
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.authors="Container Performance Tools Team"
+LABEL org.opencontainers.image.url="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.documentation="https://github.com/redhat-nfvpe/container-perf-tools/blob/main/README.md"
+LABEL org.opencontainers.image.source="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.licenses="GPL-2.0"
+LABEL org.opencontainers.image.vendor="Container Performance Tools Team"
+
+# Install packages and clean up in single layer for smaller image size
 USER root
 COPY oslat/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install realtime-tests kernel-tools dumb-init \
-    && yum clean all && rm -rf /var/cache/yum \
-    && chmod 777 /root/cmd.sh
+RUN yum -y update \
+    && yum -y install \
+        realtime-tests \
+        kernel-tools \
+        dumb-init \
+    && yum clean all \
+    && rm -rf /var/cache/yum \
+    && chmod +x /root/cmd.sh
+
+# Set working directory
 WORKDIR /root
+
+# Use dumb-init to handle signals properly
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Default command
 CMD ["/root/cmd.sh"]

--- a/Dockerfile-rtla
+++ b/Dockerfile-rtla
@@ -1,11 +1,40 @@
-# Using fedora to get a recent version of the rtla package
-FROM fedora:39
+FROM fedora:42
+
+# Build arguments
+ARG COMMIT_SHA=unknown
+ARG BUILD_DATE
+ARG VERSION
+
+# Metadata labels following OCI image specification
+LABEL org.opencontainers.image.title="rtla performance testing container"
+LABEL org.opencontainers.image.description="Container for running rtla real-time latency analysis"
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.authors="Container Performance Tools Team"
+LABEL org.opencontainers.image.url="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.documentation="https://github.com/redhat-nfvpe/container-perf-tools/blob/main/README.md"
+LABEL org.opencontainers.image.source="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.licenses="GPL-2.0"
+LABEL org.opencontainers.image.vendor="Container Performance Tools Team"
+
+# Install packages and clean up in single layer for smaller image size
 USER root
 COPY rtla/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install rtla dumb-init \
-    && yum clean all && rm -rf /var/cache/yum \
-    && chmod 777 /root/cmd.sh
+RUN yum -y update \
+    && yum -y install \
+        rtla \
+        dumb-init \
+    && yum clean all \
+    && rm -rf /var/cache/yum \
+    && chmod +x /root/cmd.sh
+
+# Set working directory
 WORKDIR /root
+
+# Use dumb-init to handle signals properly
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Default command
 CMD ["/root/cmd.sh"]

--- a/Dockerfile-stress-ng
+++ b/Dockerfile-stress-ng
@@ -1,10 +1,40 @@
-FROM fedora:39
+FROM fedora:42
+
+# Build arguments
+ARG COMMIT_SHA=unknown
+ARG BUILD_DATE
+ARG VERSION
+
+# Metadata labels following OCI image specification
+LABEL org.opencontainers.image.title="stress-ng performance testing container"
+LABEL org.opencontainers.image.description="Container for running stress-ng system stress testing"
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.authors="Container Performance Tools Team"
+LABEL org.opencontainers.image.url="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.documentation="https://github.com/redhat-nfvpe/container-perf-tools/blob/main/README.md"
+LABEL org.opencontainers.image.source="https://github.com/redhat-nfvpe/container-perf-tools"
+LABEL org.opencontainers.image.licenses="GPL-2.0"
+LABEL org.opencontainers.image.vendor="Container Performance Tools Team"
+
+# Install packages and clean up in single layer for smaller image size
 USER root
 COPY stress-ng/cmd.sh /root
 COPY common-libs /root/common-libs
-RUN yum -y install stress-ng dumb-init \
-    && yum clean all && rm -rf /var/cache/yum \
-    && chmod 777 /root/cmd.sh
+RUN yum -y update \
+    && yum -y install \
+        stress-ng \
+        dumb-init \
+    && yum clean all \
+    && rm -rf /var/cache/yum \
+    && chmod +x /root/cmd.sh
+
+# Set working directory
 WORKDIR /root
+
+# Use dumb-init to handle signals properly
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Default command
 CMD ["/root/cmd.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,169 @@
+# Container Performance Tools Makefile
+# Variables
+REGISTRY ?= quay.io
+ORG ?= container-perf-tools
+COMMIT_SHA := $(shell git rev-parse --short HEAD)
+ARCH := $(shell uname -m)
+BASE_VERSION ?= latest
+VERSION := $(BASE_VERSION)-$(ARCH)
+
+# All container images (default to all)
+IMAGES ?= cyclictest hwlatdetect oslat rtla stress-ng
+
+# Default target
+.DEFAULT_GOAL := help
+
+# Help target
+.PHONY: help
+help: ## Show this help message
+	@echo "Container Performance Tools Build System"
+	@echo ""
+	@echo "Current configuration:"
+	@echo "  Architecture: $(ARCH)"
+	@echo "  Base Version: $(BASE_VERSION)"
+	@echo "  Full Version: $(VERSION)"
+	@echo "  Registry: $(REGISTRY)"
+	@echo "  Organization: $(ORG)"
+	@echo "  Images: $(IMAGES)"
+	@echo ""
+	@echo "Available targets:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# Build targets for individual images
+.PHONY: build-cyclictest
+build-cyclictest: ## Build cyclictest image
+	podman build \
+		--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+		--build-arg VERSION=$(BASE_VERSION) \
+		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+		-f Dockerfile-cyclictest \
+		-t $(REGISTRY)/$(ORG)/cyclictest:$(BASE_VERSION) \
+		.
+
+.PHONY: build-hwlatdetect
+build-hwlatdetect: ## Build hwlatdetect image
+	podman build \
+		--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+		--build-arg VERSION=$(BASE_VERSION) \
+		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+		-f Dockerfile-hwlatdetect \
+		-t $(REGISTRY)/$(ORG)/hwlatdetect:$(BASE_VERSION) \
+		.
+
+.PHONY: build-oslat
+build-oslat: ## Build oslat image
+	podman build \
+		--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+		--build-arg VERSION=$(BASE_VERSION) \
+		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+		-f Dockerfile-oslat \
+		-t $(REGISTRY)/$(ORG)/oslat:$(BASE_VERSION) \
+		.
+
+.PHONY: build-rtla
+build-rtla: ## Build rtla image
+	podman build \
+		--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+		--build-arg VERSION=$(BASE_VERSION) \
+		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+		-f Dockerfile-rtla \
+		-t $(REGISTRY)/$(ORG)/rtla:$(BASE_VERSION) \
+		.
+
+.PHONY: build-stress-ng
+build-stress-ng: ## Build stress-ng image
+	podman build \
+		--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+		--build-arg VERSION=$(BASE_VERSION) \
+		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+		-f Dockerfile-stress-ng \
+		-t $(REGISTRY)/$(ORG)/stress-ng:$(BASE_VERSION) \
+		.
+
+# Build all images
+.PHONY: build-all
+build-all: $(addprefix build-,$(IMAGES)) ## Build all images
+
+# Push targets
+.PHONY: push-cyclictest
+push-cyclictest: ## Push cyclictest image
+	podman push $(REGISTRY)/$(ORG)/cyclictest:$(BASE_VERSION)
+
+.PHONY: push-hwlatdetect
+push-hwlatdetect: ## Push hwlatdetect image
+	podman push $(REGISTRY)/$(ORG)/hwlatdetect:$(BASE_VERSION)
+
+.PHONY: push-oslat
+push-oslat: ## Push oslat image
+	podman push $(REGISTRY)/$(ORG)/oslat:$(BASE_VERSION)
+
+.PHONY: push-rtla
+push-rtla: ## Push rtla image
+	podman push $(REGISTRY)/$(ORG)/rtla:$(BASE_VERSION)
+
+.PHONY: push-stress-ng
+push-stress-ng: ## Push stress-ng image
+	podman push $(REGISTRY)/$(ORG)/stress-ng:$(BASE_VERSION)
+
+.PHONY: push-all
+push-all: $(addprefix push-,$(IMAGES)) ## Push all images
+
+# Utility targets
+.PHONY: clean
+clean: ## Clean up images
+	podman rmi $(REGISTRY)/$(ORG)/cyclictest:$(BASE_VERSION) || true
+	podman rmi $(REGISTRY)/$(ORG)/hwlatdetect:$(BASE_VERSION) || true
+	podman rmi $(REGISTRY)/$(ORG)/oslat:$(BASE_VERSION) || true
+	podman rmi $(REGISTRY)/$(ORG)/rtla:$(BASE_VERSION) || true
+	podman rmi $(REGISTRY)/$(ORG)/stress-ng:$(BASE_VERSION) || true
+	podman rmi $(REGISTRY)/$(ORG)/container-perf-tools:$(BASE_VERSION) || true
+
+.PHONY: clean-all
+clean-all: clean ## Clean up all images and dangling images
+	podman system prune -f
+
+# Architecture-specific targets
+.PHONY: show-arch
+show-arch: ## Show current architecture
+	@echo "Current architecture: $(ARCH)"
+	@echo "Full version tag: $(VERSION)"
+
+.PHONY: build-multiarch
+build-multiarch: ## Build for multiple architectures and create manifest
+	@echo "Building multi-architecture images..."
+	@for image in $(IMAGES); do \
+		echo "Building multi-arch $$image..."; \
+		echo "  Building amd64..."; \
+		podman build --platform linux/amd64 \
+			--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+			--build-arg VERSION=$(BASE_VERSION) \
+			--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+			-f Dockerfile-$$image -t $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION)-amd64 .; \
+		echo "  Building arm64..."; \
+		podman build --platform linux/arm64 \
+			--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+			--build-arg VERSION=$(BASE_VERSION) \
+			--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+			-f Dockerfile-$$image -t $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION)-arm64 .; \
+		echo "  Creating manifest for $$image..."; \
+		podman manifest create $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION); \
+		podman manifest add $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION) $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION)-amd64; \
+		podman manifest add $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION) $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION)-arm64; \
+	done
+
+.PHONY: push-multiarch
+push-multiarch: ## Push multi-architecture manifests (including images)
+	@echo "Pushing multi-architecture manifests..."
+	@for image in $(IMAGES); do \
+		echo "Pushing manifest for $$image..."; \
+		podman manifest push --all $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION) docker://$(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION); \
+	done
+
+.PHONY: clean-multiarch
+clean-multiarch: ## Clean up multi-architecture podman images
+	@for image in $(IMAGES); do \
+		echo "Removing $$image amd64 and arm64 images..."; \
+		podman rmi $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION)-amd64; \
+		podman rmi $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION)-arm64; \
+		podman rmi $(REGISTRY)/$(ORG)/$$image:$(BASE_VERSION); \
+	done

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ standalone-trafficgen containers. To build those containers one needs to go to t
 
 ### Building the container
 
-For example, to build the oslat container image:
-`podman build -t <your repo tag> -f Dockerfile-oslat .`
+There is a Makefile available to build the stand-alone test containers. Run `make help` for instructions.
 
 ## Running the tests
 


### PR DESCRIPTION
Adding a Makefile to and enhancing the Dockerfiles for the stand-alone test images (e.g. cyclictest, oslat). Some of the improvements:
- Allow build/push of single arch or multi-arch images.
- Include a set of OCI labels in each image to point to the documentation, source, commit, etc...
- Upversioned all base images to fedora:42 to pick up many fixes and a more recent version of realtime-tests.

Assisted-by: claude-4-sonnet