### PR TITLE
Clean up source: fix typos, stale refs, shebang

### DIFF
--- a/dpdk-testpmd/cmd.sh
+++ b/dpdk-testpmd/cmd.sh
@@ -46,7 +46,7 @@ if [ -n "${pci_list}" ]; then
 fi
     
 if [[ -z "${pci_west}" || -z "${pci_east}" ]]; then
-	echo "Coudln't get assigned pci slot info from enviroment vars starting with PCIDEVICE"
+	echo "Couldn't get assigned pci slot info from environment vars starting with PCIDEVICE"
         exit 1
 fi
 

--- a/oslat/cmd.sh
+++ b/oslat/cmd.sh
@@ -31,7 +31,7 @@ rpm -q realtime-tests
 cpulist=`get_allowed_cpuset`
 echo "allowed cpu list: ${cpulist}"
 
-# change list seperators from comma to new line and sort it 
+# change list separators from comma to new line and sort it
 cpulist=`convert_number_range ${cpulist} | tr , '\n' | sort -n | uniq`
 
 declare -a cpus

--- a/rtla/cmd.sh
+++ b/rtla/cmd.sh
@@ -136,7 +136,7 @@ done
 cpulist=$(get_allowed_cpuset)
 log_echo "allowed cpu list: $cpulist"
 
-# change list seperators from comma to new line and sort it
+# change list separators from comma to new line and sort it
 cpulist=`convert_number_range ${cpulist} | tr , '\n' | sort -n | uniq`
 
 declare -a cpus

--- a/standalone-testpmd/mod.sh
+++ b/standalone-testpmd/mod.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 VERSION=${1#"v"}

--- a/sysjitter/cmd.sh
+++ b/sysjitter/cmd.sh
@@ -27,7 +27,7 @@ THRESHOLD_NS=${THRESHOLD_NS:-200}
 cpulist=`get_allowed_cpuset`
 echo "allowed cpu list: ${cpulist}"
 
-# change list seperators from comma to new line and sort it 
+# change list separators from comma to new line and sort it
 cpulist=`convert_number_range ${cpulist} | tr , '\n' | sort -n | uniq`
 
 declare -a cpus

--- a/testpmd/cmd.sh
+++ b/testpmd/cmd.sh
@@ -46,7 +46,7 @@ if [ -n "${pci_list}" ]; then
 fi
     
 if [[ -z "${pci_west}" || -z "${pci_east}" ]]; then
-	echo "Coudln't get assigned pci slot info from enviroment vars starting with PCIDEVICE"
+	echo "Couldn't get assigned pci slot info from environment vars starting with PCIDEVICE"
         exit 1
 fi
 


### PR DESCRIPTION
Fix typos in error messages and comments:
- "Coudln't" -> "Couldn't" (dpdk-testpmd, testpmd)
- "enviroment" -> "environment" (dpdk-testpmd, testpmd)
- "seperators" -> "separators" (oslat, rtla, sysjitter)

Replace stale docker.io/cscojianzhan/* image references
with quay.io/container-perf-tools/* in pod_stress_cyclictest,
standalone-testpmd/README, standalone-trafficgen/README.

Fix shebang in standalone-testpmd/mod.sh: #\!/bin/sh -> #\!/bin/bash
(script uses bash arrays).

Assisted-by: Claude:claude-opus-4-6
