### PR TITLE
Add compact_ranges to convert CPU lists to range notation

### DIFF
--- a/common-libs/functions.sh
+++ b/common-libs/functions.sh
@@ -17,6 +17,29 @@ function convert_number_range() {
 }
 
 
+function compact_ranges() {
+	# [ "$(compact_ranges "1,3,2,0,5,6,7")" = "0-3,5-7" ]
+	local cpus_list=$(convert_number_range "$1")
+	local res=""
+	local start="" prev=""
+	for cpu in $(echo "$cpus_list" | tr ',' '\n' | sort -nu); do
+		if [ ! "$start" ]; then
+			start=$cpu
+		elif [ $cpu -ne $((prev + 1)) ]; then
+			res+=",$start"
+			[ "$start" -ne "$prev" ] && res+="-$prev"
+			start=$cpu
+		fi
+		prev=$cpu
+	done
+	if [ "$start" ]; then
+		res+=",$start"
+		[ "$start" -ne "$prev" ] && res+="-$prev"
+	fi
+	echo "${res#,}"
+}
+
+
 function get_allowed_cpuset() {
 	local cpuset=`cat /proc/self/status | grep Cpus_allowed_list: | cut -f 2`
 	echo ${cpuset}

--- a/cyclictest/cmd.sh
+++ b/cyclictest/cmd.sh
@@ -95,6 +95,7 @@ if [[ "${sibling}" =~ ^[0-9]+$ ]]; then
     cyccore=${cyccore//,$sibling/}
     ccount=$(($ccount - 1))
 fi
+cyccore=$(compact_ranges "$cyccore")
 echo "new cpu list: ${cyccore}"
 
 if [[ -n "${TRACE_THRESHOLD}" ]]; then

--- a/oslat/cmd.sh
+++ b/oslat/cmd.sh
@@ -55,6 +55,7 @@ if [[ "${sibling}" =~ ^[0-9]+$ ]]; then
         echo "removing cpu${sibling} from the cpu list because it is a sibling of cpu${cpus[0]} which will be the cpu-main-thread"
         cyccore=${cyccore//,$sibling/}
 fi
+cyccore=$(compact_ranges "$cyccore")
 echo "new cpu list: ${cyccore}"
 
 extra_args=""

--- a/rtla/cmd.sh
+++ b/rtla/cmd.sh
@@ -156,6 +156,7 @@ if [[ "${sibling}" =~ ^[0-9]+$ ]]; then
     log_echo "removing cpu${sibling} from the cpu list because it is a sibling of cpu${cpus[0]} which will be the cpu-main-thread"
     cyccore=${cyccore//,$sibling/}
 fi
+cyccore=$(compact_ranges "$cyccore")
 log_echo "new cpu list: ${cyccore}"
 
 if [ ${COMMAND} == "timerlat" ] || [ ${COMMAND} == "osnoise" ]; then

--- a/stress-ng/cmd.sh
+++ b/stress-ng/cmd.sh
@@ -62,6 +62,7 @@ if [[ -z "${CMDLINE}" ]]; then
         ccount=$(($ccount + 1))
     done
 
+    newcpulist=$(compact_ranges "$newcpulist")
     echo "cpu list: ${newcpulist}"
 
     command="stress-ng -t ${DURATION} --cpu ${ccount} --taskset ${newcpulist} --cpu-method ${CPU_METHOD} --cpu-load ${CPU_LOAD} --metrics-brief ${EXTRA_ARGS}"


### PR DESCRIPTION
## Summary
- Add `compact_ranges()` function as reverse of `convert_number_range()` -
  converts comma-separated CPU lists like `1,2,3,5` to range notation `1-3,5`
- Use it in cyclictest, oslat, rtla, stress-ng to pass compacted
  ranges to tool args, avoiding issues with long comma-separated lists

Closes #38

Tested on https://quay.io/organization/costa.shul and Ice Like with as few as only 64 CPUs