### PR TITLE
Return rtla exit code from cmd.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ timerlat supports the following environment variables:
 + EVENTS_TRIGGER: Optional. Specifies the condition for the event trigger. Note: Currently only works on the last event in the list
 + CHECK_US: Allows RTLA to also check for userspace induced latency. Options are 'y' or 'n'. Default is 'n'. Note: Host kernel must support this.
 + CGROUPS: If set to 'y', it places the rtla kthreads in the same cgroup as the userspace threads. Default is 'n'. Choices are 'y' or 'n'. Note: Host kernel must support this.
-+ PAUSE: pauses after run. choices y/n; default: y
++ PAUSE: pauses after run. choices y/n; default: y. With PAUSE=n, the pod exits with the tool's return code
 + EXTRA_ARGS (default "", will be passed directly to timerlat command)
 
 ### osnoise test
@@ -341,7 +341,7 @@ osnoise supports the following environment variables:
 + EVENTS_TRIGGER: Optional. Specifies the condition for the event trigger. Note: Currently only works on the last event in the list
 + CHECK_US: Allows RTLA to also check for userspace induced latency. Options are 'y' or 'n'. Default is 'n'. Note: Host kernel must support this.
 + CGROUPS: If set to 'y', it places the rtla kthreads in the same cgroup as the userspace threads. Default is 'n'. Choices are 'y' or 'n'. Note: Host kernel must support this.
-+ PAUSE: pauses after run. choices y/n; default: y
++ PAUSE: pauses after run. choices y/n; default: y. With PAUSE=n, the pod exits with the tool's return code
 + EXTRA_ARGS (default "", will be passed directly to osnoise command)
 
 ### hwnoise test
@@ -359,5 +359,5 @@ hwnoise supports the following environment variables:
 + EVENTS_TRIGGER: Optional. Specifies the condition for the event trigger. Note: Currently only works on the last event in the list
 + CHECK_US: Allows RTLA to also check for userspace induced latency. Options are 'y' or 'n'. Default is 'n'. Note: Host kernel must support this.
 + CGROUPS: If set to 'y', it places the rtla kthreads in the same cgroup as the userspace threads. Default is 'n'. Choices are 'y' or 'n'. Note: Host kernel must support this.
-+ PAUSE: pauses after run. choices y/n; default: y
++ PAUSE: pauses after run. choices y/n; default: y. With PAUSE=n, the pod exits with the tool's return code
 + EXTRA_ARGS (default "", will be passed directly to hwnoise command)

--- a/rtla/cmd.sh
+++ b/rtla/cmd.sh
@@ -12,6 +12,8 @@
 #   CHECK_US (Allows RTLA to also check for userspace induced latency. Options are 'y' or 'n'. Default is 'n'.)
 #   CGROUPS (If set to 'y', it places the rtla kthreads in the same cgroup as the userspace threads. Default is 'n'. Choices are 'y' or 'n'.
 #   EXTRA_ARGS (Allows specifying custom options. Default is blank. Provide as a space separated list of options.)
+#
+# Exit code: propagates rtla return code
 
 source common-libs/functions.sh
 
@@ -244,6 +246,7 @@ if [[ "${DELAY}" != "0" ]]; then
 fi
 
 output=$(eval "$formatted_command")
+rc=$?
 log_echo "$output"
 
 # Right now hwnoise saves its trace as osnoise
@@ -279,3 +282,5 @@ if [[ "$PAUSE" == "y" ]]; then
     log_echo "=================================================="
     sleep infinity
 fi
+
+exit $rc


### PR DESCRIPTION
rtla/cmd.sh was swallowing the rtla exit code, always
exiting 0. Capture the return code after eval and exit
with it so pod phase reflects test pass/fail.
With PAUSE=n, the pod exits with the tool's return code.

Assisted-by: Claude:claude-opus-4-6
