### PR TITLE
Add PAUSE env var to several tool containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ oslat supports the following environment variables:
 + delay: specify how many second to delay before test start; default 0
 + TRACE_THRESHOLD: stop the oslat test when threshold triggered (in usec); no default
 + EXTRA_ARGS (default "", will be passed directly to oslat command)
++ PAUSE: pauses after run. choices y/n; default: y. With PAUSE=n, the pod exits with the tool's return code
 
 ### cyclictest test
 
@@ -232,6 +233,7 @@ cyclictest supports the following environment variables:
 + delay: specify how many seconds to delay before test start; default 0
 + TRACE_THRESHOLD: stop the cyclictest when threshold triggered (in usec); no default
 + EXTRA_ARGS (default "", will be passed directly to cyclictest command)
++ PAUSE: pauses after run. choices y/n; default: y. With PAUSE=n, the pod exits with the tool's return code
 
 ### stress-ng test
 
@@ -243,6 +245,7 @@ stress-ng supports the following environment variables:
 + CPU_LOAD: load each CPU with P percent loading, default: 100
 + EXTRA_ARGS (default "", will be passed directly to stress-ng command)
 + CMDLINE (default "", the full set of options passed to stress-ng command, overrides all other options)
++ PAUSE: pauses after run. choices y/n; default: y. With PAUSE=n, the pod exits with the tool's return code
 
 
 ### sysjitter test
@@ -307,6 +310,7 @@ hwlatdetect supports the following environment variables:
 + delay: specify how many seconds to delay before test start; default 0
 + THRESHOLD: only record hardware latencies above THRESHOLD (in usec); no default
 + EXTRA_ARGS (default "", will be passed directly to hwlatdetect command)
++ PAUSE: pauses after run. choices y/n; default: y. With PAUSE=n, the pod exits with the tool's return code
 
 ### timerlat test
 

--- a/cyclictest/cmd.sh
+++ b/cyclictest/cmd.sh
@@ -9,6 +9,7 @@
 #   TRACE_THRESHOLD: stop cyclictest when threshold triggered (in usec); no default
 #   EXTRA_ARGS (default "", will be passed directly to cyclictest command)
 #   manual (default 'n', choice y/n, don't run test - for debug purposes)
+#   PAUSE (default 'y', choice y/n, pause after run)
 
 source common-libs/functions.sh
 
@@ -111,11 +112,14 @@ if [ "${manual:-n}" == "n" ]; then
         sleep ${delay}
     fi
     $command
+    rc=$?
 else
     sleep infinity
 fi
 
-# kill stress before exit 
+# kill stress before exit
 tmux kill-session -t stress 2>/dev/null
 
-sleep infinity
+[[ "${PAUSE:-y}" == "y" ]] && sleep infinity
+
+exit $rc

--- a/dpdk-testpmd/cmd.sh
+++ b/dpdk-testpmd/cmd.sh
@@ -5,6 +5,7 @@
 #	manual    (default n, choices y/n)
 #	peer_mac_west peer_mac_east (optional), use mac forward mode if provided; otherwise io mode
 #	queues (default 1)
+#	PAUSE (default 'y', choice y/n, pause after run)
 
 source common-libs/functions.sh
 
@@ -152,7 +153,7 @@ else
 	tmux new-session -s testpmd -d "${testpmd_cmd}"
 fi
 
-sleep infinity
+[[ "${PAUSE:-y}" == "y" ]] && sleep infinity
 tmux kill-session -t testpmd
 sleep 1
 bind_driver ${vf_driver}

--- a/hwlatdetect/cmd.sh
+++ b/hwlatdetect/cmd.sh
@@ -5,7 +5,8 @@
 #   manual (default 'n', choice y/n, don't run test - for debug purposes)
 #   delay   (default 0, specify how many second to delay before test start)
 #   THRESHOLD (no default, only record hardware latencies above THRESHOLD (in usec))
-#   EXTRA_ARGS (default "", will be passed directly to oslat command)
+#   EXTRA_ARGS (default "", will be passed directly to hwlatdetect command)
+#   PAUSE (default 'y', choice y/n, pause after run)
 
 source common-libs/functions.sh
 
@@ -48,5 +49,8 @@ if [ "${delay:-0}" != "0" ]; then
 fi
 
 $command
+rc=$?
 
-sleep infinity
+[[ "${PAUSE:-y}" == "y" ]] && sleep infinity
+
+exit $rc

--- a/oslat/cmd.sh
+++ b/oslat/cmd.sh
@@ -8,6 +8,7 @@
 #   delay   (default 0, specify how many second to delay before test start)
 #   TRACE_THRESHOLD (no default, stop the oslat test when threshold triggered (in usec))
 #   EXTRA_ARGS (default "", will be passed directly to oslat command)
+#   PAUSE (default 'y', choice y/n, pause after run)
 
 source common-libs/functions.sh
 
@@ -86,5 +87,8 @@ if [ "${delay:-0}" != "0" ]; then
 fi
 
 $command
+rc=$?
 
-sleep infinity
+[[ "${PAUSE:-y}" == "y" ]] && sleep infinity
+
+exit $rc

--- a/stress-ng/cmd.sh
+++ b/stress-ng/cmd.sh
@@ -6,6 +6,7 @@
 #   CPU_LOAD (default "100")
 #   EXTRA_ARGS (default "", will be passed directly to stress-ng command)
 #   CMDLINE (default "", the full set of options passed to stress-ng command, overrides all other options)
+#   PAUSE (default 'y', choice y/n, pause after run)
 
 source common-libs/functions.sh
 
@@ -76,8 +77,11 @@ echo "running cmd: ${command}"
 
 if [ "${manual:-n}" == "n" ]; then
     $command
+    rc=$?
 else
     sleep infinity
 fi
 
-sleep infinity
+[[ "${PAUSE:-y}" == "y" ]] && sleep infinity
+
+exit $rc


### PR DESCRIPTION
Several tools had unconditional sleep infinity at the end,
keeping pods running after test completion. Replace with
conditional PAUSE (default y) matching rtla's existing
pattern.

Assisted-by: Claude:claude-opus-4-6
